### PR TITLE
FIX: Ajustar validação para limite por palavras

### DIFF
--- a/src/components/steps/stepbystep/StepFive.vue
+++ b/src/components/steps/stepbystep/StepFive.vue
@@ -1,34 +1,69 @@
 <script setup>
+import { computed, watch } from 'vue'
 import { useEdition } from '@/stores/edition';
 import { useWork } from '@/stores/work';
 import { useDisplay } from 'vuetify';
+
 const workStore = useWork()
 const editionStore = useEdition()
 const { width, height } = useDisplay()
 const wComputed = computed(() => width.value)
 
-const RowComputed = computed(() => {
-    if (height.value < 750) {
-        return 8
-    }
-    return 15
+const RowComputed = computed(() => height.value < 750 ? 8 : 15)
+
+const maxWords = computed(() => editionStore.currentEdition?.words_per_work_max || 0)
+const minWords = computed(() => editionStore.currentEdition?.words_per_work_min || 0)
+
+const wordCount = computed(() => {
+    const text = workStore.WorkStorage.abstract?.trim() || ''
+    return text ? text.split(/\s+/).length : 0
 })
+
+const abstractColor = computed(() =>
+    maxWords.value > 0 && wordCount.value === maxWords.value ? 'error' : undefined
+)
+
+// Enforce max words by preventing new content when limit is reached
+watch(() => workStore.WorkStorage.abstract, (val) => {
+    if (!val || maxWords.value === 0) return
+    const words = val.trim().split(/\s+/)
+    if (words.length > maxWords.value) {
+        workStore.WorkStorage.abstract = words.slice(0, maxWords.value).join(' ')
+    }
+})
+
+const abstractRules = [
+    () => wordCount.value >= minWords.value || `Mínimo de ${minWords.value} palavras`,
+    () => (maxWords.value === 0 || wordCount.value <= maxWords.value) || `Máximo de ${maxWords.value} palavras`
+]
 </script>
+
 <template>
     <div class="w-100 pa-2 d-flex flex-column ga-5 max-w-100 ">
-        <div :style="{ width: width <= 375 ? '90%' : '70%', marginBottom: '80px', margin: '0 auto'}" class="pa-2 d-flex flex-column ga-5 h-100 ">
+        <div :style="{ width: width <= 375 ? '90%' : '70%', marginBottom: '80px', margin: '0 auto' }"
+            class="pa-2 d-flex flex-column ga-5 h-100 ">
 
-            <VLabel >Título do Trabalho</VLabel>
+            <VLabel>Título do Trabalho</VLabel>
             <div>
                 <v-text-field v-model="workStore.WorkStorage.title" maxlength="200"></v-text-field>
             </div>
-             <div class="d-flex ga-2 mt-5">
-            <p style="font-size: 12px;">* Limite mínimo de palavras: {{ editionStore.currentEdition.words_per_work_min }}</p>
-            <p style="font-size: 12px;">* Limite máximo de palavras: {{ editionStore.currentEdition.words_per_work_max }}</p>
-        </div>
+            <div class="d-flex ga-2 mt-5">
+                <p style="font-size: 12px;">* Limite mínimo de palavras: {{
+                    editionStore.currentEdition.words_per_work_min }}</p>
+                <p style="font-size: 12px;">* Limite máximo de palavras: {{
+                    editionStore.currentEdition.words_per_work_max }}</p>
+            </div>
             <div>
-                <VTextarea v-model="workStore.WorkStorage.abstract" :counter="editionStore.currentEdition.words_per_work_max" :maxlength="editionStore.currentEdition.words_per_work_max" 
-                    variant="outlined" auto-grow rounded="xl" :rows="RowComputed" ></VTextarea>
+                <VTextarea v-model="workStore.WorkStorage.abstract" variant="outlined" auto-grow rounded="xl"
+                    :rows="RowComputed" :rules="abstractRules" :color="abstractColor">
+                    <template #counter>
+                        <span :class="{
+                            'text-error': wordCount < minWords || (maxWords > 0 && wordCount === maxWords)
+                        }">
+                            {{ wordCount }} / {{ maxWords }} palavras
+                        </span>
+                    </template>
+                </VTextarea>
             </div>
         </div>
     </div>

--- a/src/interfaces/edition.ts
+++ b/src/interfaces/edition.ts
@@ -37,7 +37,6 @@ export interface IEdition {
   works_per_advisor_max: number;
   words_per_work_min: number;
   words_per_work_max: number;
-  words_per_work_min: number;
   workload: number;
 
   // Mídia

--- a/src/pages/panel/works/add/index.vue
+++ b/src/pages/panel/works/add/index.vue
@@ -33,8 +33,11 @@ const ReturnValidatedtoDisabledBtn = computed(() => {
   if (actualstep.value === 3) {
     return workStore.WorkStorage.collaborators?.length < editionStore?.currentEdition?.collaborators_min
   }
-  if(actualstep.value === 4){
-    return workStore.WorkStorage.abstract.length < editionStore.currentEdition.words_per_work_min
+  if (actualstep.value === 4) {
+    const min = editionStore.currentEdition?.words_per_work_min || 0
+    const abstract = workStore.WorkStorage.abstract?.trim() || ''
+    const words = abstract ? abstract.split(/\s+/).length : 0
+    return words < min
   }
   return false
 })


### PR DESCRIPTION
This pull request enhances the abstract input validation for works, ensuring that word count limits are enforced consistently across the UI and logic. The main changes introduce computed properties and rules to manage minimum and maximum word counts, provide user feedback, and prevent exceeding the allowed word count.

**Abstract word count enforcement and UI feedback:**

* Added computed properties and watchers in `StepFive.vue` to enforce minimum and maximum word counts for the abstract, automatically trimming excess words and providing real-time feedback to users.
* Updated the abstract input field in `StepFive.vue` to display a dynamic counter, highlight errors when limits are reached, and apply validation rules for both minimum and maximum word counts.
* Improved validation logic for the "Next" button in the works addition flow (`index.vue`) to check the actual word count against the minimum requirement, rather than relying on string length.

**Codebase cleanup:**

* Removed a duplicate `words_per_work_min` field from the `IEdition` interface in `edition.ts` to prevent confusion and maintain type integrity.