### PR TITLE
REFACTOR: fixes help button in submission menu

### DIFF
--- a/src/components/steps/layout/StepsHeader.vue
+++ b/src/components/steps/layout/StepsHeader.vue
@@ -1,34 +1,37 @@
 <script setup>
 import { useDisplay } from 'vuetify';
 
-    defineProps({
-        user: {
-            type: Object,
-            required: true
-        },
-        step_num: {
-            type: Number,
-            required: true
-        },
-        step_value: {
-            type: String,
-            required: true
-        },
-        step_completed: {
-            type: Boolean,
-            required: true
-        }
-    })
-    const {width} = useDisplay()
+defineProps({
+    user: {
+        type: Object,
+        required: true
+    },
+    step_num: {
+        type: Number,
+        required: true
+    },
+    step_value: {
+        type: String,
+        required: true
+    },
+    step_completed: {
+        type: Boolean,
+        required: true
+    }
+})
+const { width } = useDisplay()
 </script>
 <template>
     <div class="d-flex justify-space-between align-center pa-2">
         <div class="d-flex justify-center align-center">
             <div v-if="width < 950" class="d-flex jusitfy-center align-center ga-2">
-                <VChip class="bg-blue " rounded="15" v-if="step_num">{{ !step_completed ? Number(step_num) : '✔'}}</VChip>
+                <VChip class="bg-blue " rounded="15" v-if="step_num">{{ !step_completed ? Number(step_num) : '✔' }}
+                </VChip>
                 <p class="text-blue">{{ step_value }}</p>
             </div>
-            <p class="text-blue ms-10" style="font-size: 15px;" v-if="width > 950">Precisa de Ajuda?</p>
+            <router-link to="/user-support">
+                <p class="text-blue ms-10" style="font-size: 15px;" v-if="width > 950">Precisa de Ajuda?</p>
+            </router-link>
         </div>
         <div class="d-flex align-center jusitfy-center ga-3" v-if="width > 950">
             <VImg :src="user.img" width="40" rounded="xl"></VImg>

--- a/src/pages/panel/works/add/index.vue
+++ b/src/pages/panel/works/add/index.vue
@@ -166,11 +166,11 @@ onMounted(async () => {
       </router-link>
       <VDivider></VDivider>
       <VList>
-        <VListItem prepend-icon="mdi-information">
-          precisa de ajuda?
-        </VListItem>
         <VListItem prepend-icon="mdi-account">
           <VListItemTitle>{{ AuthStore.user.name }}</VListItemTitle>
+        </VListItem>
+        <VListItem prepend-icon="mdi-information">
+          <router-link to="/user-support">Precisa de ajuda?</router-link>
         </VListItem>
       </VList>
     </VNavigationDrawer>


### PR DESCRIPTION
This pull request introduces improvements to the user support experience by updating the way help links are presented in the UI. The most important changes are focused on making the "Precisa de Ajuda?" (Need Help?) support link more visible and interactive.

**User Support Link Enhancements:**

* In `StepsHeader.vue`, the "Precisa de Ajuda?" text is now wrapped in a `router-link`, making it clickable and directing users to the `/user-support` page when viewed on wide screens.
* In `add/index.vue`, the support link in the navigation drawer is now a clickable `router-link` to `/user-support`, replacing the previous static text for better user navigation.