### PR TITLE
FIX: refactor conditional rendering for evaluator, advisor, and colla…

### DIFF
--- a/src/components/work/members/TeacherContainer.vue
+++ b/src/components/work/members/TeacherContainer.vue
@@ -25,26 +25,28 @@ const checkWorks = () => {
 <template>
     <div class="w-100 d-flex justify-center flex-column ga-10">
         <div v-if="checkWorks()">
-        <div v-if="props.works.evaluatorWorks.length > 0 " class="w-100 d-flex align-center flex-column">
-        <h2>Avaliar</h2>
-        <slot name="evaluate">
+            <div v-if="(['TEACHER', 'TAE'].includes(props.user_type)) && (props.works.evaluatorWorks?.length > 0)"
+                class="w-100 d-flex align-center flex-column">
+                <h2>Avaliar</h2>
+                <slot name="evaluate">
 
-        </slot>
-        </div>
+                </slot>
+            </div>
 
-         <div v-if="props.user_type == 'TEACHER' && props.works.advisorWorks.length > 0" class="w-100 d-flex align-center flex-column mt-10">
-        <h2>Orientar</h2>
-        <slot name="advise">
+            <div v-if="props.user_type == 'TEACHER' && props.works.advisorWorks.length > 0"
+                class="w-100 d-flex align-center flex-column mt-10">
+                <h2>Orientar</h2>
+                <slot name="advise">
 
-        </slot>
-        </div>
+                </slot>
+            </div>
 
-         <div v-if="props.works.collaboratorWorks.length > 0 " class="w-100 d-flex align-center flex-column  mt-10">
-        <h2>Colaborar</h2>
-        <slot name="collaborate">
+            <div v-if="props.works.collaboratorWorks.length > 0" class="w-100 d-flex align-center flex-column  mt-10">
+                <h2>Colaborar</h2>
+                <slot name="collaborate">
 
-        </slot>
-        </div>
+                </slot>
+            </div>
         </div>
         <div v-else>
             <p>Você não foi chamado para participar de nenhum projeto.</p>


### PR DESCRIPTION
This pull request updates the logic for displaying work sections in the `TeacherContainer.vue` component. The main change is to make the "Avaliar" section visible for both `TEACHER` and `TAE` user types, and to ensure the section only appears if there are evaluator works. The "Orientar" section remains exclusive to the `TEACHER` user type.

Improvements to conditional rendering:

* The "Avaliar" section now appears for both `TEACHER` and `TAE` user types, and only if `evaluatorWorks` exist, by updating the conditional to `(['TEACHER', 'TAE'].includes(props.user_type)) && (props.works.evaluatorWorks?.length > 0)` in `TeacherContainer.vue`.
* The "Orientar" section's conditional remains unchanged, ensuring it's shown only for `TEACHER` users with advisor works.…borator sections in TeacherContainer